### PR TITLE
added fatal error (#93)

### DIFF
--- a/pkg/synth/acl.go
+++ b/pkg/synth/acl.go
@@ -2,7 +2,6 @@
 package synth
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/np-guard/vpc-network-config-synthesis/pkg/ir"
@@ -17,7 +16,7 @@ func MakeACL(s *ir.Spec, opt Options) *ir.ACLCollection {
 	aclSelector := func(ip ir.IP) string {
 		result, ok := s.Defs.SubnetNameFromIP(ip)
 		if !ok {
-			return fmt.Sprintf("<unknown subnet %v>", ip)
+			log.Fatalf("ACL: src/dst of type network interface (or instance) is not supported.")
 		}
 		return result
 	}


### PR DESCRIPTION
A fatal error will be raised when the user uses an instance type as src or dst in the required connections for ACL.