### PR TITLE
Update go-jsonschema to atombender version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint-go:
 
 lint-json:
 	@echo -- $@ --
-	check-jsonschema test/data/*/conn_spec.json examples/generic_example.json  --schemafile spec_schema.json
+	check-jsonschema test/data/*/conn_spec.json examples/generic_example.json --schemafile spec_schema.json
 
 lint: lint-go lint-json
 
@@ -31,8 +31,8 @@ precommit: mod fmt lint
 
 pkg/io/jsonio/data_model.go: spec_schema.json
 	@echo -- generate --
-	# Install https://github.com/omissis/go-jsonschema
-	gojsonschema spec_schema.json --package jsonio --struct-name-from-title --tags json --output $@
+	# Install https://github.com/atombender/go-jsonschema
+	go-jsonschema spec_schema.json --package jsonio --struct-name-from-title --tags json --output $@
 	goimports -local $(REPOSITORY) -w $@
 
 generate: pkg/io/jsonio/data_model.go

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ bin\vpcgen.exe -target=sg -config test\data\sg_testing2\config_object.json test\
 
 ## Code generation
 
-Install [omissis/go-jsonschema](https://github.com/omissis/go-jsonschema)
+Install [atombender/go-jsonschema](https://github.com/atombender/go-jsonschema)
 (important: **not** [xeipuuv/gojsonschema](https://github.com/xeipuuv/gojsonschema))
 
 ```commandline
-go install github.com/omissis/go-jsonschema
+go get github.com/atombender/go-jsonschema
+go install github.com/atombender/go-jsonschema
 ```
 
 Then run

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Install [atombender/go-jsonschema](https://github.com/atombender/go-jsonschema)
 (important: **not** [xeipuuv/gojsonschema](https://github.com/xeipuuv/gojsonschema))
 
 ```commandline
-go get github.com/atombender/go-jsonschema
-go install github.com/atombender/go-jsonschema
+go get github.com/atombender/go-jsonschema/...
+go install github.com/atombender/go-jsonschema@latest
 ```
 
 Then run


### PR DESCRIPTION
The old gojsonschema command from https://github.com/omissis/go-jsonschema does not seem to be installable anymore. It is changed to go-jsonschema from https://github.com/atombender/go-jsonschema as explained there.
(Both links lead to the same web page.)