### PR TITLE
Fix makefile so it runs on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 REPOSITORY := github.com/np-guard/vpc-network-config-synthesis
-EXE := vpcgen.exe
+ifeq ($(OS),Windows_NT)
+    TARGETNAME = vpcgen.exe
+else
+    TARGETNAME = vpcgen
+endif
+TARGET = ./bin/$(TARGETNAME)
 
-./bin/$(EXE): build
+$(TARGET): build
 
 .PHONY: mod fmt lint generate build test jd-test
 
@@ -39,14 +44,14 @@ generate: pkg/io/jsonio/data_model.go
 
 build:
 	@echo -- $@ --
-	CGO_ENABLED=0 go build -o ./bin/$(EXE) ./cmd/vpcgen
+	CGO_ENABLED=0 go build -o $(TARGET) ./cmd/vpcgen
 
 test:
 	@echo -- $@ --
 	go test ./... -v -cover -coverprofile synth.coverprofile
 
-jd-test: ./bin/$(EXE)
+jd-test: $(TARGET)
 	@echo -- $@ --
 	# Install https://github.com/josephburnett/jd
-	./bin/$(EXE) examples/generic_example.json > tmp.json
+	$(TARGET) examples/generic_example.json > tmp.json
 	jd examples/generic_example.json tmp.json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run on Linux environment:
 ```commandline
 bin/vpcgen -target=acl -config test/data/acl_testing5/config_object.json test/data/acl_testing5/conn_spec.json
 
-$ bin/vpcgen -target=sg -config test/data/sg_testing2/config_object.json test/data/sg_testing2/conn_spec.json
+bin/vpcgen -target=sg -config test/data/sg_testing2/config_object.json test/data/sg_testing2/conn_spec.json
 ```
 
 


### PR DESCRIPTION
Generate target without `.exe` suffix on Linux platforms, so the instructions in the README file will work.