### PR TITLE
Running golangci-lint action according to docs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,16 +11,19 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: ./go.mod
-      - uses: golangci/golangci-lint-action@v3
+          cache: false
+      - uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804
+        with:
+          version: latest
   ensure-fmt:
     name: ensure-fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: ./go.mod
@@ -43,7 +46,7 @@ jobs:
       - name: Install go-jsonschema
         run: pip install check-jsonschema
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Lint
         run: make lint-json


### PR DESCRIPTION
According to the [Action docs](https://github.com/golangci/golangci-lint-action):
* The cache in `setup-go` should be disabled
* The version of golangci-lint to use must be specified

This fixes the `Cannot open: File exists` errors we see in the Action's summary